### PR TITLE
Use absolute config settings package

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -5,7 +5,7 @@ from rich.table import Table
 from rich.panel import Panel
 from rich.markdown import Markdown
 
-from src.config.settings import SETTINGS
+from config.settings import SETTINGS
 from src.ticket_fetcher import TicketFetcher
 from src.work_assistant import WorkAssistant
 from src.action_handler import ActionHandler

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,3 @@
+"""Configuration package exposing project settings."""
+
+# This file makes the `config` directory a Python package.

--- a/src/action_handler.py
+++ b/src/action_handler.py
@@ -4,7 +4,7 @@ import requests
 from typing import Optional
 from .models import CVEDetails, Script, Ticket, Result
 from .llm_client import LLMClient
-from .config.settings import SETTINGS
+from config.settings import SETTINGS
 
 ART_DIR = os.path.join(os.path.dirname(__file__), "..", "artifacts")
 os.makedirs(ART_DIR, exist_ok=True)

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import List, Optional
 from .models import Ticket, CVEDetails, Script
-from .config.settings import SETTINGS
+from config.settings import SETTINGS
 
 class LLMClient:
     def analyze(self, tickets: List[Ticket]) -> str:

--- a/src/ticket_fetcher.py
+++ b/src/ticket_fetcher.py
@@ -4,7 +4,7 @@ from typing import List
 from datetime import datetime
 import requests
 from .models import Ticket, TicketDetail
-from .config.settings import SETTINGS
+from config.settings import SETTINGS
 
 CACHE_FILE = os.path.join(os.path.dirname(__file__), "..", ".ticket_cache.json")
 


### PR DESCRIPTION
## Summary
- import settings via `from config.settings import SETTINGS`
- declare `config` as a package for easier imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src'; pre-existing syntax issue in src/llm_client.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b766872314832ba74192378e6d9b0e